### PR TITLE
update for peridio CLI >= 1.0.0 usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ env/
 .installed.cfg
 build/
 dist/
+.venv

--- a/peridio_evk/commands/devices.py
+++ b/peridio_evk/commands/devices.py
@@ -354,7 +354,10 @@ def do_register_devices(devices, product_name, cohort_prn):
         log_info(f'Device Certificate: {device["certificate"]}')
         log_info(f'Device Private Key: {device["private_key"]}')
 
-        result = peridio_cli(['peridio', '--profile', evk_config['profile'], 'devices', 'create', '--identifier', device['identifier'], '--product-name', product_name, '--cohort-prn', cohort_prn, '--tags', f'{" ".join(device["tags"])}', '--target', device["target"]])
+        result = peridio_cli(['peridio', '--profile', evk_config['profile'], 'devices',
+                              'create', '--identifier', device['identifier'],
+                              '--product-name', product_name, '--cohort-prn',
+                              cohort_prn, '--tags', f'{",".join(device["tags"])}', '--target', device["target"]])
         if result.returncode != 0:
             log_skip_task('Device already exists')
 

--- a/peridio_evk/commands/devices.py
+++ b/peridio_evk/commands/devices.py
@@ -346,7 +346,7 @@ def do_create_device_certificates(devices, signer_ca):
 
     return devices
 
-def do_register_devices(devices, product_name, cohort_prn):
+def do_register_devices(devices, product_prn, cohort_prn):
     evk_config = read_evk_config()
     for device in devices:
         log_task(f'Registering Device')
@@ -356,11 +356,24 @@ def do_register_devices(devices, product_name, cohort_prn):
 
         result = peridio_cli(['peridio', '--profile', evk_config['profile'], 'devices',
                               'create', '--identifier', device['identifier'],
-                              '--product-name', product_name, '--cohort-prn',
+                              '--product-prn', product_prn, '--cohort-prn',
                               cohort_prn, '--tags', f'{",".join(device["tags"])}', '--target', device["target"]])
         if result.returncode != 0:
             log_skip_task('Device already exists')
+            result = peridio_cli(['peridio', '--profile', evk_config['profile'],
+                                  'devices', 'list', '--search',
+                                  f'identifier:\'{device['identifier']}\''])
+            response = json.loads(result.stdout)
+            if len(response['devices']) == 1:
+                device_prn = response['devices'][0]['prn']
+            else:
+                sys.exit()
+        else:
+            response = json.loads(result.stdout)
+            device_prn = response['device']['prn']
 
-        result = peridio_cli(['peridio', '--profile', evk_config['profile'], 'device-certificates', 'create', '--device-identifier', device['identifier'], '--product-name', product_name, '--certificate-path', device['certificate']])
+        result = peridio_cli(['peridio', '--profile', evk_config['profile'],
+                              'device-certificates', 'create', '--device-prn',
+                              device_prn, '--certificate-path', device['certificate']])
         if result.returncode != 0:
             log_skip_task('Device certificate already exists')

--- a/peridio_evk/commands/initialize.py
+++ b/peridio_evk/commands/initialize.py
@@ -48,7 +48,7 @@ def initialize(organization_name, organization_prn, api_key, product_name):
         default=False,
     ):
         do_initialize(organization_name, organization_prn, api_key)
-        cohort_prns = do_create_product(product_name)
+        product_prn, cohort_prns = do_create_product(product_name)
         release_cohort = find_dict_by_name(cohort_prns, "release")
         release_cohort_prn = release_cohort["prn"]
         release, artifacts = do_create_artifacts(organization_prn, release_cohort_prn)
@@ -57,7 +57,7 @@ def initialize(organization_name, organization_prn, api_key, product_name):
             devices, release_cohort["ca"]
         )
         filtered_devices = filter_dicts(updated_devices, "tags", ["canary"])
-        do_register_devices(filtered_devices, product_name, release_cohort_prn)
+        do_register_devices(filtered_devices, product_prn, release_cohort_prn)
 
 
 def do_initialize(organization_name, organization_prn, api_key):

--- a/peridio_evk/product.py
+++ b/peridio_evk/product.py
@@ -25,7 +25,7 @@ def do_create_product(name):
         product_prn = response['product']['prn']
     log_info(f'Product PRN: {product_prn}')
     cohorts = create_product_cohorts(product_prn, name)
-    return cohorts
+    return product_prn, cohorts
 
 def create_product_cohorts(product_prn, product_name):
     evk_config = read_evk_config()

--- a/peridio_evk/product.py
+++ b/peridio_evk/product.py
@@ -11,12 +11,12 @@ def do_create_product(name):
     log_info(f'Product Name: {name}')
 
     evk_config = read_evk_config()
-    result = peridio_cli(['peridio', '--profile', evk_config['profile'], 'products-v2', 'create', '--name', name, '--organization-prn', evk_config['organization_prn']])
+    result = peridio_cli(['peridio', '--profile', evk_config['profile'], 'products', 'create', '--name', name, '--organization-prn', evk_config['organization_prn']])
     if result.returncode != 0:
         response = json.loads(result.stderr)
         if "has already been taken" in response['data']['params']['name']:
             log_skip_task('Product already exists')
-        result = peridio_cli(['peridio', '--profile', evk_config['profile'], 'products-v2', 'list', '--search', f'organization_prn:\'{evk_config["organization_prn"]}\' and name:\'{name}\''])
+        result = peridio_cli(['peridio', '--profile', evk_config['profile'], 'products', 'list', '--search', f'name:\'{name}\''])
         if result.returncode == 0:
             response = json.loads(result.stdout)
             product_prn = response['products'][0]['prn']
@@ -45,7 +45,7 @@ def create_product_cohorts(product_prn, product_name):
         result = peridio_cli(['peridio', '--profile', evk_config['profile'], 'cohorts', 'create', '--name', cohort, '--description', desc, '--organization-prn', evk_config['organization_prn'], '--product-prn', product_prn])
         if result.returncode != 0:
             log_skip_task('Cohort already exists')
-            result = peridio_cli(['peridio', '--profile', evk_config['profile'], 'cohorts', 'list', '--search', f'organization_prn:\'{evk_config["organization_prn"]}\' and name:\'{cohort}\''])
+            result = peridio_cli(['peridio', '--profile', evk_config['profile'], 'cohorts', 'list', '--search', f'name:\'{cohort}\''])
             if result.returncode == 0:
                 response = json.loads(result.stdout)
                 cohort_prn = response['cohorts'][0]['prn']
@@ -83,13 +83,15 @@ def create_product_cohort_ca(product_name, cohort_name, cohort_prn):
 
     log_task(f'Registering Intermediate CA')
     ca_certificate_serial = str(read_ca_serial_number(intermediate_ca_cert))
-    result = peridio_cli(['peridio', '--profile', evk_config['profile'], 'ca-certificates', 'get', '--ca-certificate-serial', ca_certificate_serial])
-    if result.returncode != 0:
+    result = peridio_cli(['peridio', '--profile', evk_config['profile'], 'ca-certificates', 'list', '--search', f'description~\'Serial: {ca_certificate_serial}\''])
+    response = json.loads(result.stdout)
+    ca_certificate_exists = len(response['ca_certificates']) == 1
+    if not ca_certificate_exists:
         log_task(f'Generating CA Certificate Verification Code')
         result = peridio_cli(['peridio', '--profile', evk_config['profile'], 'ca-certificates', 'create-verification-code'])
         if result.returncode == 0:
             response = json.loads(result.stdout)
-            verification_code = response['data']['verification_code']
+            verification_code = response['verification_code']
             log_info(f'Verification Code: {verification_code}')
 
         log_task(f'Signing Verification Certificate')
@@ -104,9 +106,14 @@ def create_product_cohort_ca(product_name, cohort_name, cohort_prn):
 
         print(intermediate_ca_cert)
 
-        result = peridio_cli(['peridio', '--profile', evk_config['profile'], 'ca-certificates', 'create', '--certificate-path', intermediate_ca_cert, '--verification-certificate-path', verification_ca_cert, '--description', f'Intermediate CA: {product_name}:{cohort_name}', '--jitp-cohort-prn', cohort_prn, '--jitp-product-name', product_name, '--jitp-tags', 'JITP', '--jitp-description', 'JITP', '--jitp-target', 'arm64-v8'])
+        result = peridio_cli(['peridio', '--profile', evk_config['profile'],
+                              'ca-certificates', 'create', '--certificate-path',
+                              intermediate_ca_cert, '--verification-certificate-path',
+                              verification_ca_cert, '--description', f'Intermediate CA: {product_name}:{cohort_name}. Serial: {ca_certificate_serial}'])
+                              # '--jitp-cohort-prn', cohort_prn, '--jitp-product-name', product_name, '--jitp-tags', 'JITP', '--jitp-description', 'JITP', '--jitp-target', 'arm64-v8'])
         if result.returncode != 0:
             log_error(result.stderr)
+            sys.exit()
     else:
         log_skip_task(f'Intermediate CA Already Registered')
 
@@ -134,7 +141,7 @@ def create_cohort_signing_key(cohort_name, cohort_prn):
 
     public_key_raw = convert_ed25519_public_pem_to_raw(cohort_public_key_pem)
     public_key_raw_encoded = base64.b64encode(public_key_raw).decode('utf-8')
-    result = peridio_cli(['peridio', '--profile', evk_config['profile'], 'signing-keys', 'list', '--search', f'organization_prn:\'{evk_config["organization_prn"]}\' and value:\'{public_key_raw_encoded}\''])
+    result = peridio_cli(['peridio', '--profile', evk_config['profile'], 'signing-keys', 'list', '--search', f'value:\'{public_key_raw_encoded}\''])
     signing_key_name = f'{cohort_name}-signing-key'
 
     if result.returncode == 0:

--- a/peridio_evk/releases.py
+++ b/peridio_evk/releases.py
@@ -4,7 +4,7 @@ from peridio_evk.log import *
 def do_create_artifacts(organization_prn, cohort_prn):
     log_task('Creating Artifacts')
     artifacts_start = [
-        {'name': 'edge-inference-os', 'description': 'Edge Inference Product OS', 'version': 'v1.12.1', 'targets': [{'target': 'arm64-v8', 'bytes': 67108864}, {'target': 'x86_64', 'bytes': 69206016}], 
+        {'name': 'edge-inference-os', 'description': 'Edge Inference Product OS', 'version': 'v1.12.1', 'targets': [{'target': 'arm64-v8', 'bytes': 67108864}, {'target': 'x86_64', 'bytes': 69206016}],
             "custom_metadata": {"peridiod": {"installer": "fwup", "installer_opts": {"cache_enabled": False}, "reboot_required": True}}},
         {'name': 'edge-inference-service', 'description': 'Edge Inference Service', 'version': 'v1.5.3', 'targets': [{'target': 'arm64-v8', 'bytes': 10485760}, {'target': 'x86_64', 'bytes': 14680064}],
             "custom_metadata": {"peridiod": {"installer": "file", "installer_opts": {"path": "/opt/edge-inference", "name": "edge-inference-service.img", "reboot_required": False}}}},
@@ -15,7 +15,7 @@ def do_create_artifacts(organization_prn, cohort_prn):
     ]
 
     artifacts_end = [
-        {'name': 'edge-inference-os', 'description': 'Edge Inference Product OS', 'version': 'v1.12.1', 'targets': [{'target': 'arm64-v8', 'bytes': 67108864}, {'target': 'x86_64', 'bytes': 69206016}], 
+        {'name': 'edge-inference-os', 'description': 'Edge Inference Product OS', 'version': 'v1.12.1', 'targets': [{'target': 'arm64-v8', 'bytes': 67108864}, {'target': 'x86_64', 'bytes': 69206016}],
             "custom_metadata": {"peridiod": {"installer": "fwup", "installer_opts": {"cache_enabled": False}, "reboot_required": True}}},
         {'name': 'edge-inference-service', 'description': 'Edge Inference Service', 'version': 'v2.0.0', 'targets': [{'target': 'arm64-v8', 'bytes': 10486260}, {'target': 'x86_64', 'bytes': 14685064}],
             "custom_metadata": {"peridiod": {"installer": "file", "installer_opts": {"path": "/opt/edge-inference", "name": "edge-inference-service.img", "reboot_required": False}}}},
@@ -27,7 +27,7 @@ def do_create_artifacts(organization_prn, cohort_prn):
 
     bundle_start, artifacts = do_create_artifacts_bundle(artifacts_start, 'r1001', organization_prn)
     bundle_end, _artifacts = do_create_artifacts_bundle(artifacts_end, 'r1002', organization_prn)
-    
+
     release_from = do_create_release('release-r1001', organization_prn, cohort_prn, bundle_start, '1.1.0', '', False, [])
     do_create_release('release-r1002', organization_prn, cohort_prn, bundle_end, '2.0.0', '~> 1.1', True, ['canary'])
     return release_from, artifacts
@@ -41,7 +41,7 @@ def do_create_artifacts_bundle(artifacts, bundle_name, organization_prn):
         result = peridio_cli(['peridio', '--profile', evk_config['profile'], 'artifacts', 'create', '--organization-prn', evk_config['organization_prn'], '--name', artifact['name'], '--description', artifact['description'], '--custom-metadata', json.dumps(artifact['custom_metadata'])])
         if result.returncode != 0:
             log_skip_task('Artifact Exists')
-            result = peridio_cli(['peridio', '--profile', evk_config['profile'], 'artifacts', 'list', '--search', f'organization_prn:\'{evk_config["organization_prn"]}\' and name:\'{artifact["name"]}\''])
+            result = peridio_cli(['peridio', '--profile', evk_config['profile'], 'artifacts', 'list', '--search', f'name:\'{artifact["name"]}\''])
             response = json.loads(result.stdout)
             artifact_prn = response['artifacts'][0]['prn']
         else:
@@ -53,7 +53,7 @@ def do_create_artifacts_bundle(artifacts, bundle_name, organization_prn):
         result = peridio_cli(['peridio', '--profile', evk_config['profile'], 'artifact-versions', 'create', '--artifact-prn', artifact_prn, '--version', artifact['version'], '--description', artifact['version']])
         if result.returncode != 0:
             log_skip_task('Artifact Version Exists')
-            result = peridio_cli(['peridio', '--profile', evk_config['profile'], 'artifact-versions', 'list', '--search', f'organization_prn:\'{evk_config["organization_prn"]}\' and artifact_prn:\'{artifact_prn}\' and description:\'{artifact["version"]}\''])
+            result = peridio_cli(['peridio', '--profile', evk_config['profile'], 'artifact-versions', 'list', '--search', f'artifact_prn:\'{artifact_prn}\' and description:\'{artifact["version"]}\''])
             response = json.loads(result.stdout)
             artifact_version_prn = response['artifact_versions'][0]['prn']
         else:
@@ -61,7 +61,7 @@ def do_create_artifacts_bundle(artifacts, bundle_name, organization_prn):
             response = json.loads(result.stdout)
             artifact_version_prn = response['artifact_version']['prn']
             log_info(f'Artifact Version PRN: {artifact_version_prn}')
-        
+
         artifact_version_prns.append(artifact_version_prn)
 
         config_path = get_config_path()
@@ -89,7 +89,7 @@ def do_create_artifacts_bundle(artifacts, bundle_name, organization_prn):
                 log_info(f'Binary PRN: {binary_prn}')
             target['binary_prn'] = binary_prn
 
-    result = peridio_cli(['peridio', '--profile', evk_config['profile'], 'bundles', 'create', '--artifact-version-prns', f'{" ".join(artifact_version_prns)}', '--name', bundle_name, '--organization-prn', organization_prn])
+    result = peridio_cli(['peridio', '--profile', evk_config['profile'], 'bundles', 'create', '--artifact-version-prns', f'{",".join(artifact_version_prns)}', '--name', bundle_name, '--organization-prn', organization_prn])
     if result.returncode == 0:
         log_task('Creating Bundle')
         log_info(f'Bundle Name: {bundle_name}')
@@ -97,7 +97,7 @@ def do_create_artifacts_bundle(artifacts, bundle_name, organization_prn):
         bundle_prn = response['bundle']['prn']
     else:
         log_skip_task('Bundle already Exists')
-        result = peridio_cli(['peridio', '--profile', evk_config['profile'], 'bundles', 'list', '--search', f'organization_prn:\'{evk_config["organization_prn"]}\' and name:\'{bundle_name}\''])
+        result = peridio_cli(['peridio', '--profile', evk_config['profile'], 'bundles', 'list', '--search', f'name:\'{bundle_name}\''])
         response = json.loads(result.stdout)
         bundle_prn = response['bundles'][0]['prn']
     return bundle_prn, artifacts
@@ -118,14 +118,14 @@ def do_create_release(release_name, organization_prn, cohort_prn, bundle_prn, ve
         command.append('1.0')
     else:
         command.append('--phase-tags')
-        command.append(f'{" ".join(phase_tags)}')
-    
+        command.append(f'{",".join(phase_tags)}')
+
     result = peridio_cli(command)
     if result.returncode == 0:
         response = json.loads(result.stdout)
         release = response['release']
     else:
-        result = peridio_cli(['peridio', '--profile', evk_config['profile'], 'releases', 'list', '--search', f'organization_prn:\'{evk_config["organization_prn"]}\' and version:\'{version}\''])
+        result = peridio_cli(['peridio', '--profile', evk_config['profile'], 'releases', 'list', '--search', f'version:\'{version}\''])
         if result.returncode == 0:
             response = json.loads(result.stdout)
             release = response['releases'][0]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="peridio_evk",
-    version="0.1.7",
+    version="0.1.8",
     author="Peridio Developers",
     author_email="support@peridio.com",
     description="The Peridio Evaluation Kit",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="peridio_evk",
-    version="0.1.6",
+    version="0.1.7",
     author="Peridio Developers",
     author_email="support@peridio.com",
     description="The Peridio Evaluation Kit",


### PR DESCRIPTION
- Ignore venvs.
- Multi-value CLI args use "," delimiter.
- Drop organization_prn from searches.
- Use "products" (was previously "products-v2" which got promoted).
- Search for existing CAs by listing instead of getting (since get no longer uses serial as the primary key).
- Temporarily disable JITP configuration on the CA since that is no longer supported on "ca-certificates create" as previously specified. In the future it is planned to allow this again albeit in a slightly different fashion, at that time the EVK will be updated to leverage it again.
- Bump version to 0.1.7.